### PR TITLE
Wrapped JSON.stringify() in try catch to avoid app crash due to JSON parse errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eropple/bunyan-wrapper",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Presents a subset of a Bunyan API that allows libraries to do some structured logging.",
   "main": "dist",
   "author": "Ed Ropple",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eropple/bunyan-wrapper",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Presents a subset of a Bunyan API that allows libraries to do some structured logging.",
   "main": "dist",
   "author": "Ed Ropple",
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "yarn exec -- tsc",
     "watch": "yarn build --watch",
-    "test": "yarn exec jest",
+    "test": "jest",
     "prepare": "yarn test && yarn build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "yarn exec -- tsc",
     "watch": "yarn build --watch",
-    "test": "NODE_ENV=test yarn exec jest",
+    "test": "yarn exec jest",
     "prepare": "yarn test && yarn build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eropple/bunyan-wrapper",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Presents a subset of a Bunyan API that allows libraries to do some structured logging.",
   "main": "dist",
   "author": "Ed Ropple",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "private": false,
   "scripts": {
-    "build": "yarn exec -- tsc",
+    "build": "tsc",
     "watch": "yarn build --watch",
     "test": "jest",
     "prepare": "yarn test && yarn build"

--- a/src/bunyan-wrapper.ts
+++ b/src/bunyan-wrapper.ts
@@ -21,7 +21,11 @@ export class BunyanWrapper implements BunyanLike {
     if (!msg) {
       this._logger.trace(d);
     } else {
-      this._logger.trace(`${msg} ${JSON.stringify(d)}`);
+      try {
+        this._logger.trace(`${msg} ${JSON.stringify(d)}`);
+      } catch (error) {
+        this._logger.trace(`Error ${msg} ${error}`);
+      }
     }
   }
 
@@ -33,7 +37,11 @@ export class BunyanWrapper implements BunyanLike {
     if (!msg) {
       this._logger.debug(d);
     } else {
-      this._logger.debug(`${msg} ${JSON.stringify(d)}`);
+      try {
+        this._logger.debug(`${msg} ${JSON.stringify(d)}`);
+      } catch (error) {
+        this._logger.debug(`Error ${msg} ${error}`);
+      }
     }
   }
 
@@ -45,7 +53,11 @@ export class BunyanWrapper implements BunyanLike {
     if (!msg) {
       this._logger.info(d);
     } else {
-      this._logger.info(`${msg} ${JSON.stringify(d)}`);
+      try {
+        this._logger.info(`${msg} ${JSON.stringify(d)}`);
+      } catch (error) {
+        this._logger.info(`Error ${msg} ${error}`);
+      }
     }
   }
 
@@ -57,7 +69,11 @@ export class BunyanWrapper implements BunyanLike {
     if (!msg) {
       this._logger.warn(d);
     } else {
-      this._logger.warn(`${msg} ${JSON.stringify(d)}`);
+      try {
+        this._logger.warn(`${msg} ${JSON.stringify(d)}`);
+      } catch (error) {
+        this._logger.warn(`Error ${msg} ${error}`);
+      }
     }
   }
 
@@ -69,7 +85,11 @@ export class BunyanWrapper implements BunyanLike {
     if (!msg) {
       this._logger.error(d);
     } else {
-      this._logger.error(`${msg} ${JSON.stringify(d)}`);
+      try {
+        this._logger.error(`${msg} ${JSON.stringify(d)}`);
+      } catch (error) {
+        this._logger.error(`Error ${msg} ${error}`);
+      }
     }
   }
 
@@ -81,7 +101,11 @@ export class BunyanWrapper implements BunyanLike {
     if (!msg) {
       this._logger.error(`FATAL: ${d}`);
     } else {
-      this._logger.error(`FATAL: ${msg} ${JSON.stringify(d)}`);
+      try {
+        this._logger.error(`FATAL: ${msg} ${JSON.stringify(d)}`);
+      } catch (error) {
+        this._logger.error(`Error: ${msg} ${error}`);
+      }
     }
   }
 }


### PR DESCRIPTION
I had and issues that the @eropple/nestjs-openapi3 would fail if I had circular references in the modules to be scanned.
It turns out the problem was due to an error when doing a `JSON.stringify` on said object and this caused the app to crash.
I have wrapped all `JSON.stringify()` calls in try-catch to void this problem.